### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/ImageStoreServer/package.json
+++ b/ImageStoreServer/package.json
@@ -15,6 +15,7 @@
     "express": "^5.1.0",
     "luxon": "^3.7.1",
     "multer": "^2.0.2",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^8.1.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/linuskang/bubbly/security/code-scanning/8](https://github.com/linuskang/bubbly/security/code-scanning/8)

To fix this problem, we should add rate limiting to the specific route in question (`GET /upload`), or potentially all routes serving files. The standard solution in Express applications is to use the `express-rate-limit` package. This package allows for fine-grained control of rate limiting on a per-route or global basis. The best and most backwards-compatible fix is to import `express-rate-limit`, define a limiter (e.g., 100 requests per 15 minutes per IP), and add it as the first handler for the affected `/upload` route (line 80). This avoids impacting other routes or requiring changes to the structure or authentication logic. The changes needed are: require the package, define the limiter, and use it as middleware on the relevant route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
